### PR TITLE
docs: explicit label should not be implicitly declared

### DIFF
--- a/adev/src/content/tutorials/learn-angular/steps/15-forms/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/15-forms/README.md
@@ -15,10 +15,8 @@ In this activity, you'll learn how to setup a form using a template-driven appro
 In `user.component.ts`, update the template by adding a text input with the `id` set to `framework`, type set to `text`.
 
 ```html
-<label for="framework">
-  Favorite Framework:
-  <input id="framework" type="text" />
-</label>
+<label for="framework">Favorite Framework:</label>
+<input id="framework" type="text" />
 ```
 
 </docs-step>
@@ -50,10 +48,8 @@ The `FormsModule` has a directive called `ngModel` that binds the value of the i
 Update the input to use the `ngModel` directive, specifically with the following syntax `[(ngModel)]="favoriteFramework"` to bind to the `favoriteFramework` property.
 
 <docs-code language="html" highlight="[3]">
-<label for="framework">
-  Favorite Framework:
-  <input id="framework" type="text" [(ngModel)]="favoriteFramework" />
-</label>
+<label for="framework">Favorite Framework:</label>
+<input id="framework" type="text" [(ngModel)]="favoriteFramework" />
 </docs-code>
 
 After you've made changes, try entering a value in the input field. Notice how it updates on the screen (yes, very cool).

--- a/adev/src/content/tutorials/learn-angular/steps/15-forms/answer/src/app/user.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/15-forms/answer/src/app/user.component.ts
@@ -6,10 +6,8 @@ import {FormsModule} from '@angular/forms';
   template: `
     <p>Username: {{ username }}</p>
     <p>{{ username }}'s favorite framework: {{ favoriteFramework }}</p>
-    <label for="framework">
-      Favorite Framework:
-      <input id="framework" type="text" [(ngModel)]="favoriteFramework" />
-    </label>
+    <label for="framework">Favorite Framework:</label>
+    <input id="framework" type="text" [(ngModel)]="favoriteFramework" />
   `,
   standalone: true,
   imports: [FormsModule],


### PR DESCRIPTION
This input is nested in the label and has the `for` property, which is not the recommended way by MDN. 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: N/A

The template has the `input` element in the `label` while having a `for` declared.

## What is the new behavior?

Unnest the input. Another solution to this would be to change it to an implicitly declared approach *(which I feel is not as nice as the explicit declaration)*

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Another way of handling this would be with the implicit approach:
```html
<label>
  Favorite Framework:
  <input type="text" [(ngModel)]="favoriteFramework" />
</label>
```

Reference for info <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label> 
